### PR TITLE
Update dependency versions for ImgLib2 6.x et al

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>33.2.0</version>
+		<version>34.1.0</version>
 		<relativePath />
 	</parent>
 
@@ -97,7 +97,12 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
-		<imglib2.version>6.0.0</imglib2.version>
+		<imglib2.version>6.1.0</imglib2.version>
+		<imglib2-algorithm.version>0.13.1</imglib2-algorithm.version>
+		<imglib2-cache.version>1.0.0-beta-17</imglib2-cache.version>
+		<imglib2-realtransform.version>4.0.1</imglib2-realtransform.version>
+		<imglib2-roi.version>0.14.0</imglib2-roi.version>
+		<bigdataviewer-core.version>10.4.6</bigdataviewer-core.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/org/janelia/thickness/EstimateScalingFactors.java
+++ b/src/main/java/org/janelia/thickness/EstimateScalingFactors.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/ShiftCoordinates.java
+++ b/src/main/java/org/janelia/thickness/ShiftCoordinates.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/InferFromMatrix.java
+++ b/src/main/java/org/janelia/thickness/inference/InferFromMatrix.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/Options.java
+++ b/src/main/java/org/janelia/thickness/inference/Options.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/fits/AbstractCorrelationFit.java
+++ b/src/main/java/org/janelia/thickness/inference/fits/AbstractCorrelationFit.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/fits/GlobalCorrelationFitAverage.java
+++ b/src/main/java/org/janelia/thickness/inference/fits/GlobalCorrelationFitAverage.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/fits/GlobalCorrelationFitAverageRegularized.java
+++ b/src/main/java/org/janelia/thickness/inference/fits/GlobalCorrelationFitAverageRegularized.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/fits/LocalCorrelationFitAverage.java
+++ b/src/main/java/org/janelia/thickness/inference/fits/LocalCorrelationFitAverage.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/CSVVisitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/CSVVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/CorrelationFitVisitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/CorrelationFitVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/FileSaverVisitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/FileSaverVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/GlobalCorrelationFitVisitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/GlobalCorrelationFitVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/LUTVisitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/LUTVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/LazyVisitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/LazyVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/ListVisitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/ListVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/MatrixVisitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/MatrixVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/PermutedLUTVisitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/PermutedLUTVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/PermutedScalingFactorsVisitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/PermutedScalingFactorsVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/ScalingFactorsVisitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/ScalingFactorsVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/inference/visitor/Visitor.java
+++ b/src/main/java/org/janelia/thickness/inference/visitor/Visitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/AbstractLUTGrid.java
+++ b/src/main/java/org/janelia/thickness/lut/AbstractLUTGrid.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/AbstractLUTRealTransform.java
+++ b/src/main/java/org/janelia/thickness/lut/AbstractLUTRealTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/AbstractLUTRealTransformField.java
+++ b/src/main/java/org/janelia/thickness/lut/AbstractLUTRealTransformField.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/AbstractPerumtationTransform.java
+++ b/src/main/java/org/janelia/thickness/lut/AbstractPerumtationTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/LUTGrid.java
+++ b/src/main/java/org/janelia/thickness/lut/LUTGrid.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/LUTRealTransform.java
+++ b/src/main/java/org/janelia/thickness/lut/LUTRealTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/LUTRealTransformField.java
+++ b/src/main/java/org/janelia/thickness/lut/LUTRealTransformField.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/PermutationTransform.java
+++ b/src/main/java/org/janelia/thickness/lut/PermutationTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/SingleDimensionLUTGrid.java
+++ b/src/main/java/org/janelia/thickness/lut/SingleDimensionLUTGrid.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/SingleDimensionLUTRealTransform.java
+++ b/src/main/java/org/janelia/thickness/lut/SingleDimensionLUTRealTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/SingleDimensionLUTRealTransformField.java
+++ b/src/main/java/org/janelia/thickness/lut/SingleDimensionLUTRealTransformField.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/lut/SingleDimensionPermutationTransform.java
+++ b/src/main/java/org/janelia/thickness/lut/SingleDimensionPermutationTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/plugin/NonBlockingGenericDialogWithFileField.java
+++ b/src/main/java/org/janelia/thickness/plugin/NonBlockingGenericDialogWithFileField.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/plugin/RealSumFloatNCC.java
+++ b/src/main/java/org/janelia/thickness/plugin/RealSumFloatNCC.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/plugin/SourcePixelReader.java
+++ b/src/main/java/org/janelia/thickness/plugin/SourcePixelReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/plugin/TargetPixelWriter.java
+++ b/src/main/java/org/janelia/thickness/plugin/TargetPixelWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/plugin/ZPositionCorrection.java
+++ b/src/main/java/org/janelia/thickness/plugin/ZPositionCorrection.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/trakem2/LayerZPosition.java
+++ b/src/main/java/org/janelia/thickness/trakem2/LayerZPosition.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/thickness/trakem2/RealSumARGBNCC.java
+++ b/src/main/java/org/janelia/thickness/trakem2/RealSumARGBNCC.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/utility/MatrixStripConversion.java
+++ b/src/main/java/org/janelia/utility/MatrixStripConversion.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/utility/OuterProductView.java
+++ b/src/main/java/org/janelia/utility/OuterProductView.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/utility/OuterProductViews.java
+++ b/src/main/java/org/janelia/utility/OuterProductViews.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/utility/arrays/ArraySortedIndices.java
+++ b/src/main/java/org/janelia/utility/arrays/ArraySortedIndices.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/java/org/janelia/utility/arrays/ReplaceNaNs.java
+++ b/src/main/java/org/janelia/utility/arrays/ReplaceNaNs.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -2,7 +2,7 @@
 # #%L
 # Z spacing plugin for Fiji.
 # %%
-# Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+# Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
 # %%
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/EstimateScalingFactorsTest.java
+++ b/src/test/java/org/janelia/thickness/EstimateScalingFactorsTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/ShiftCoordinatesTest.java
+++ b/src/test/java/org/janelia/thickness/ShiftCoordinatesTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/inference/InferFromMatrixTest.java
+++ b/src/test/java/org/janelia/thickness/inference/InferFromMatrixTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/inference/OptionsTest.java
+++ b/src/test/java/org/janelia/thickness/inference/OptionsTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/lut/AbstractLUTRealTransformTest.java
+++ b/src/test/java/org/janelia/thickness/lut/AbstractLUTRealTransformTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/lut/AbstractPerumtationTransformTest.java
+++ b/src/test/java/org/janelia/thickness/lut/AbstractPerumtationTransformTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/lut/LUTGridTest.java
+++ b/src/test/java/org/janelia/thickness/lut/LUTGridTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/lut/LUTRealTransformFieldTest.java
+++ b/src/test/java/org/janelia/thickness/lut/LUTRealTransformFieldTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/lut/PermutationTransformTest.java
+++ b/src/test/java/org/janelia/thickness/lut/PermutationTransformTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/lut/SingleDimensionLUTGridTest.java
+++ b/src/test/java/org/janelia/thickness/lut/SingleDimensionLUTGridTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/lut/SingleDimensionLUTRealTransformFieldTest.java
+++ b/src/test/java/org/janelia/thickness/lut/SingleDimensionLUTRealTransformFieldTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/src/test/java/org/janelia/thickness/lut/SingleDimensionPermutationTransformTest.java
+++ b/src/test/java/org/janelia/thickness/lut/SingleDimensionPermutationTransformTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Z spacing plugin for Fiji.
  * %%
- * Copyright (C) 2014 - 2022 Howard Hughes Medical Institute.
+ * Copyright (C) 2014 - 2023 Howard Hughes Medical Institute.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as


### PR DESCRIPTION
This updates all imglib2-6.x-related dependencies to align, as well as the license header update for 2023, in preparation for a new release, which will need to exist ASAP for use in the forthcoming pom-scijava 35.0.0.
